### PR TITLE
added aptget update before the install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Rick Golden "golden@golden-garage.net"
 
 RUN update-locale LANG=C.UTF-8 LC_MESSAGES=POSIX
 
-
+RUN apt-get update
 RUN apt-get install -y software-properties-common
 RUN add-apt-repository ppa:chris-lea/node.js
 


### PR DESCRIPTION
Maybe it just happens to me because Im running a 13.04 ubuntu with a 0.5.3 docker, but during the 
"RUN apt-get install -y software-properties-common" I get a
Err http://in.archive.ubuntu.com/ubuntu/ trusty-updates/main libxml2-dev amd64 2.9.1+dfsg1-3ubuntu4.1
  404  Not Found [IP: 91.189.91.13 80]

adding a RUN apt-get update before the install of software-properties-common fixed the problem and probably wont hurt anyway =D
